### PR TITLE
feat: Enhance Portfolio and Visual System

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,15 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  /* Color Palette */
+  --color-1: #fdebc3;
+  --color-2: #e3f2ff;
+  --color-3: #f3ffe3;
+  --color-4: #f9c9c9;
+  --color-5: #a2cef1;
+  --color-6: #ffffff;
+  --color-7: #7fcec6;
 }
 
 @theme inline {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({
         <NavBar />
         <main
           className={`
-            flex min-h-screen flex-col bg-[#f7f6f3]
+            flex min-h-screen flex-col bg-[var(--color-6)]
             lg:pl-60
           `}
         >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 import About from '@/sections/about';
 import Contact from '@/sections/contact';
 import Home from '@/sections/home';
+import Portfolio from '@/sections/portfolio';
 import Resume from '@/sections/resume';
+import Service from '@/sections/service';
 
 export default function Page() {
   return (
@@ -9,8 +11,8 @@ export default function Page() {
       <Home />
       <About />
       <Resume />
-      {/* <Service />
-      <Portfolio /> */}
+      <Service />
+      <Portfolio />
       <Contact />
     </div>
   );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,7 +9,7 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 const Button = ({
   title,
   className,
-  bgColor = '#fdebc3',
+  bgColor = 'var(--color-1)',
   children,
   disabled = false,
   pressed = false,

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,18 +1,22 @@
 interface ChipProps {
   text: string;
+  size?: 'xs' | 'sm' | 'md';
   bgColor?: string; // hex color code
   textColor?: string; // hex color code
 }
 
-const Chip = ({ text, bgColor = '#00bba7', textColor = '#101828' }: ChipProps) => {
+const FontSize = {
+  xs: '0.75rem',
+  sm: '0.875rem',
+  md: '1rem'
+};
+
+const Chip = ({ size = 'sm', text, bgColor = '#00bba7', textColor = '#101828' }: ChipProps) => {
   return (
-    <div
-      style={{ backgroundColor: bgColor }}
-      className={`flex h-fit items-center justify-center rounded-sm px-1 py-0 opacity-60`}
-    >
-      <small style={{ color: textColor }} className="whitespace-nowrap">
+    <div style={{ backgroundColor: bgColor }} className={`flex h-fit w-fit rounded-sm px-1 py-0`}>
+      <span style={{ color: textColor, fontSize: FontSize[size] }} className="whitespace-nowrap">
         {text}
-      </small>
+      </span>
     </div>
   );
 };

--- a/src/components/ImageSafe.tsx
+++ b/src/components/ImageSafe.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import Image, { type ImageProps } from 'next/image';
+import { useState } from 'react';
+
+export default function ImageSafe({ src, alt, ...props }: ImageProps) {
+  const fallback = '/assets/images/hdygidev.webp';
+  const [imgSrc, setImgSrc] = useState<ImageProps['src']>(src || fallback);
+
+  return <Image {...props} src={imgSrc} alt={alt} onError={() => setImgSrc(fallback)} />;
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -73,8 +73,8 @@ const NavBar = () => {
               width={2600}
               height={3800}
               className={`
-                mx-auto h-40 w-40 rounded-full border-2 border-black bg-[var(--color-1)] object-cover
-                object-[center_25%]
+                mx-auto h-40 w-40 rounded-full border-2 border-black bg-[var(--color-1)]
+                object-cover object-[center_25%]
               `}
               src="/assets/images/me.webp"
               alt="Profile Picture"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -73,7 +73,7 @@ const NavBar = () => {
               width={2600}
               height={3800}
               className={`
-                mx-auto h-40 w-40 rounded-full border-2 border-black bg-[#fdebc3] object-cover
+                mx-auto h-40 w-40 rounded-full border-2 border-black bg-[var(--color-1)] object-cover
                 object-[center_25%]
               `}
               src="/assets/images/me.webp"
@@ -82,7 +82,7 @@ const NavBar = () => {
             <span
               className={`
                 absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border-2 border-black
-                bg-[#7fcec6] px-3 py-1 text-xs font-semibold text-black shadow-lg
+                bg-[var(--color-7)] px-3 py-1 text-xs font-semibold text-black shadow-lg
               `}
             >
               #OPENTOWORK

--- a/src/constants/HistoriesConst.ts
+++ b/src/constants/HistoriesConst.ts
@@ -40,7 +40,7 @@ export const WorkExperiences: IWorkExperience[] = [
       'Spring Boot',
       'Spring MVC'
     ],
-    color: '#a2cef1'
+    color: 'var(--color-5)'
   },
   {
     id: 2,
@@ -69,7 +69,7 @@ export const WorkExperiences: IWorkExperience[] = [
       'Redis',
       'Spring Boot'
     ],
-    color: '#f9c9c9'
+    color: 'var(--color-4)'
   },
   {
     id: 3,
@@ -103,7 +103,7 @@ export const WorkExperiences: IWorkExperience[] = [
       'Vuex',
       'styled-components'
     ],
-    color: '#F3FFe3'
+    color: 'var(--color-3)'
   },
   {
     id: 4,
@@ -119,7 +119,7 @@ export const WorkExperiences: IWorkExperience[] = [
       'Authored internal onboarding and technical documentation, reducing ramp up time by 60%'
     ],
     stacks: ['CI/CD', 'Docker', 'Git', 'Java', 'Maven', 'PostgreSQL', 'Spring Boot', 'Spring JPA'],
-    color: '#E3F2FF'
+    color: 'var(--color-2)'
   },
   {
     id: 5,
@@ -139,7 +139,7 @@ export const WorkExperiences: IWorkExperience[] = [
       'React Native',
       'Tailwind CSS'
     ],
-    color: '#fdebc3'
+    color: 'var(--color-1)'
   }
 ];
 
@@ -194,7 +194,7 @@ export const Certificates: ICertificate[] = [
     institution: 'PeopleCert',
     publishedDate: 'May 2017',
     url: CertificateUrls.qsd,
-    color: '#F3FFe3'
+    color: 'var(--color-3)'
   },
   {
     id: 2,
@@ -210,6 +210,6 @@ export const Certificates: ICertificate[] = [
     institution: 'HackerRank',
     publishedDate: 'Jul 2025',
     url: CertificateUrls.react,
-    color: '#E3F2FF'
+    color: 'var(--color-2)'
   }
 ];

--- a/src/constants/ResumeConst.ts
+++ b/src/constants/ResumeConst.ts
@@ -57,7 +57,7 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         title: 'Wonderful Quran API',
         description:
           'Designed and developed Wonderful Quran API service used by Wonderful Quran web.',
-        urlImage: '',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1GzzZ0TLTPv6M8qD2HUwBWLTCbEgD2Wth',
         stacks: ['TypeScript', 'Node.js', 'Express.js', 'AWS Lambda'],
         urlLive: 'https://wonderful-quran.netlify.app/',
         urlGitHub: 'https://github.com/ladoijo/wonderful-quran-be'
@@ -67,30 +67,30 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         slug: 'time-deposit-bank-account',
         title: 'Time Deposit Bank Account',
         description:
-          'Developed Time Deposit feature used by Hijra Bank customers for savings and investment.',
-        urlImage: '',
+          'Developed Time Deposit backend service used by Hijra Bank customers for savings and investment.',
         stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
+        urlImage: 'https://drive.google.com/uc?export=view&id=1mQMnP_mKFERosn3AFoH1XrAK4dAMF3cz',
         urlLive:
           'https://play.google.com/store/apps/details?id=com.bank_hijra&pcampaignid=web_share'
       },
-      {
-        id: 3,
-        slug: 'otp-service',
-        title: 'OTP Service',
-        description:
-          'Designed and developed OTP service used by ALAMI app users for security purposes.',
-        urlImage: '',
-        stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
-        urlLive:
-          'https://play.google.com/store/apps/details?id=com.alami_funder&pcampaignid=web_share'
-      },
+      // {
+      //   id: 3,
+      //   slug: 'otp-service',
+      //   title: 'OTP Service',
+      //   description:
+      //     'Designed and developed OTP backend service used by ALAMI app users for security purposes.',
+      //   urlImage: '',
+      //   stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
+      //   urlLive:
+      //     'https://play.google.com/store/apps/details?id=com.alami_funder&pcampaignid=web_share'
+      // },
       {
         id: 4,
         slug: 'p2p-education-module',
         title: 'P2P Education Module',
         description:
-          'Designed and developed P2P Education module used by ALAMI app users to help educate users about ALAMI P2P.',
-        urlImage: '',
+          'Designed and developed P2P Education module backend service used by ALAMI app users to help educate users about ALAMI P2P.',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1GJryAJzlHQ1c5IWEZEwREm38RYhO2SZk',
         stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
         urlLive:
           'https://play.google.com/store/apps/details?id=com.alami_funder&pcampaignid=web_share'
@@ -100,8 +100,8 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         slug: 'sfmonitor-agent-connector-amq',
         title: 'SFMonitor Agent, Connector & AMQ',
         description:
-          'SFMonitor consists of three integrated modules: SFMonitor Agent, which listens to server activity, records request histories, monitors system and JVM resources, provides thread and stack-trace controls, and sends request/response events to RabbitMQ; SFMonitor AMQ, which consumes these messages from RabbitMQ and stores them as historical data in the database; and SFMonitor Bridge, which acts as a connector between the SFMonitor Dashboard and multiple SFMonitor Agents inside Docker containers, routing dashboard requests to the correct agent based on container IP or host.',
-        urlImage: '',
+          'SFMonitor consists of three integrated modules. SFMonitor Agent, which listens to server activity, records request histories, monitors system and JVM resources, provides thread and stack-trace controls, and sends request/response events to RabbitMQ. SFMonitor AMQ, which consumes these messages from RabbitMQ and stores them as historical data in the database. And SFMonitor Bridge, which acts as a connector between the SFMonitor Dashboard and multiple SFMonitor Agents inside Docker containers, routing dashboard requests to the correct agent based on container IP or host.',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1bkEbAFrpg3E5wLeQdHha3CvLGZW5CDCX',
         stacks: ['Java', 'Spring Boot', 'RabbitMQ', 'MySQL']
       }
     ]
@@ -115,7 +115,7 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         title: 'Wonderful Quran Web',
         description:
           'Designed and developed Wonderful Quran web with fast navigation, verse exploration, and a clean study interface',
-        urlImage: '',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1GzzZ0TLTPv6M8qD2HUwBWLTCbEgD2Wth',
         stacks: ['TypeScript', 'React.js', 'Next.js', 'Tailwind CSS', 'Radix UI'],
         urlLive: 'https://wonderful-quran.netlify.app/',
         urlGitHub: 'https://github.com/ladoijo/wonderful-quran-fe'
@@ -126,7 +126,7 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         title: 'My Personal Web',
         description:
           'A personal portfolio website showcasing my projects, skills, and professional experience. Built with modern web technologies.',
-        urlImage: '',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1URAWVxm1Haoae4itIgPwBEz_yh99HH1H',
         stacks: ['TypeScript', 'React.js', 'Next.js', 'Tailwind CSS'],
         urlLive: 'https://hdygidev.netlify.app/',
         urlGitHub: 'https://github.com/ladoijo/my-personal-web'
@@ -137,7 +137,7 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         title: 'SFMonitor Dashboard',
         description:
           'Designed and developed monitoring dashboard equipped with features to monitor requests, responses, resource usage, and more from every server, VM, and Docker container service related to Lucee and ColdFusion applications.',
-        urlImage: '',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1tNCpnJzKUCs3YiccZqjhkbU6u0KQSOyM',
         stacks: ['Spring MVC', 'CSS', 'JavaScript', 'jQuery', 'Bootstrap']
       }
     ]
@@ -151,7 +151,7 @@ export const PortfolioProjects: Record<string, IPortfolioProject> = {
         title: 'Navees',
         description:
           'Developed app specializing in the buying and selling of gold bars, facilitates online gold trading using the wakalah contract, ensuring transactions align with Sharia principles for a secure and ethical experience.',
-        urlImage: '',
+        urlImage: 'https://drive.google.com/uc?export=view&id=1SIS7uIjIJ0Z9v5AEeV-KWPz9hiGdpRTY',
         stacks: ['TypeScript', 'React Native', 'Redux', 'RxJS', 'NativeBase'],
         urlLive: 'https://play.google.com/store/apps/details?id=com.navees&pcampaignid=web_share'
       }
@@ -194,7 +194,7 @@ export const Skills: ISkill = {
   backend: {
     name: 'Backend',
     Icon: BackendIcon,
-    color: '#E3F2FF',
+    color: 'var(--color-2)',
     items: [
       {
         name: 'Spring',
@@ -225,7 +225,7 @@ export const Skills: ISkill = {
   frontend: {
     name: 'Frontend',
     Icon: FrontendIcon,
-    color: '#F3FFe3',
+    color: 'var(--color-3)',
     items: [
       {
         name: 'HTML',
@@ -264,7 +264,7 @@ export const Skills: ISkill = {
   database: {
     name: 'Database',
     Icon: DatabaseIcon,
-    color: '#f9c9c9',
+    color: 'var(--color-4)',
     items: [
       {
         name: 'MySQL',
@@ -291,7 +291,7 @@ export const Skills: ISkill = {
   others: {
     name: 'Others',
     Icon: ToolsIcon,
-    color: '#a2cef1',
+    color: 'var(--color-5)',
     items: [
       {
         name: 'Docker',

--- a/src/constants/ResumeConst.ts
+++ b/src/constants/ResumeConst.ts
@@ -32,110 +32,132 @@ import TailwindIcon from '@/assets/icons/tailwindcss.svg';
 import ToolsIcon from '@/assets/icons/tools.svg';
 import TypeScriptIcon from '@/assets/icons/typescript.svg';
 import { IconComponent } from '@/types/icon';
-import { ProjectCategory, ProjectItem } from '@/types/portfolio';
 
-export const portfolioItems: ProjectItem[] = [
-  {
-    id: '1',
-    title: 'E-Commerce Platform',
-    description:
-      'A full-stack e-commerce solution built with React, Node.js, and MongoDB. Features include user authentication, payment processing, inventory management, and admin dashboard.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['React', 'Node.js', 'MongoDB', 'Stripe', 'Tailwind CSS'],
-    category: 'web',
-    liveUrl: 'https://example-ecommerce.com',
-    githubUrl: 'https://github.com/username/ecommerce-platform',
-    featured: true
-  },
-  {
-    id: '2',
-    title: 'Mobile Banking App',
-    description:
-      'A secure mobile banking application for iOS and Android with biometric authentication, transaction history, and real-time notifications.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['React Native', 'TypeScript', 'Firebase', 'Redux'],
-    category: 'mobile',
-    liveUrl: 'https://apps.apple.com/banking-app',
-    githubUrl: 'https://github.com/username/banking-app',
-    featured: true
-  },
-  {
-    id: '3',
-    title: 'Task Management Dashboard',
-    description:
-      'A collaborative task management tool with real-time updates, team collaboration features, and project tracking capabilities.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['Vue.js', 'Express', 'Socket.io', 'PostgreSQL'],
-    category: 'web',
-    liveUrl: 'https://taskmanager.example.com',
-    githubUrl: 'https://github.com/username/task-manager',
-    featured: false
-  },
-  {
-    id: '4',
-    title: 'Weather Desktop App',
-    description:
-      'A cross-platform desktop application for weather forecasting with location-based services and customizable widgets.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['Electron', 'JavaScript', 'OpenWeather API'],
-    category: 'desktop',
-    githubUrl: 'https://github.com/username/weather-app',
-    featured: false
-  },
-  {
-    id: '5',
-    title: 'UI/UX Design System',
-    description:
-      'A comprehensive design system with reusable components, style guide, and documentation for consistent user experiences.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['Figma', 'Storybook', 'CSS', 'Design Tokens'],
-    category: 'backend',
-    liveUrl: 'https://design-system.example.com',
-    featured: false
-  },
-  {
-    id: '6',
-    title: 'AI Chatbot Platform',
-    description:
-      'An intelligent chatbot platform with natural language processing, multi-language support, and analytics dashboard.',
-    image:
-      'https://img.freepik.com/free-photo/cartoon-lifestyle-summertime-scene_23-2151068217.jpg?semt=ais_incoming&w=740&q=80',
-    technologies: ['Python', 'TensorFlow', 'FastAPI', 'React'],
-    category: 'web',
-    liveUrl: 'https://chatbot.example.com',
-    githubUrl: 'https://github.com/username/ai-chatbot',
-    featured: true
-  }
-];
+export interface IPortfolioProject {
+  label: string;
+  items: {
+    id: number;
+    slug: string;
+    title: string;
+    description: string;
+    urlImage: string;
+    stacks: string[];
+    urlLive?: string;
+    urlGitHub?: string;
+  }[];
+}
 
-export const projectCategories: ProjectCategory[] = [
-  { id: 'all', label: 'All Projects', count: portfolioItems.length },
-  {
-    id: 'backend',
+export const PortfolioProjects: Record<string, IPortfolioProject> = {
+  backend: {
     label: 'Backend',
-    count: portfolioItems.filter((item) => item.category === 'backend').length
+    items: [
+      {
+        id: 1,
+        slug: 'wonderful-quran-api',
+        title: 'Wonderful Quran API',
+        description:
+          'Designed and developed Wonderful Quran API service used by Wonderful Quran web.',
+        urlImage: '',
+        stacks: ['TypeScript', 'Node.js', 'Express.js', 'AWS Lambda'],
+        urlLive: 'https://wonderful-quran.netlify.app/',
+        urlGitHub: 'https://github.com/ladoijo/wonderful-quran-be'
+      },
+      {
+        id: 2,
+        slug: 'time-deposit-bank-account',
+        title: 'Time Deposit Bank Account',
+        description:
+          'Developed Time Deposit feature used by Hijra Bank customers for savings and investment.',
+        urlImage: '',
+        stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
+        urlLive:
+          'https://play.google.com/store/apps/details?id=com.bank_hijra&pcampaignid=web_share'
+      },
+      {
+        id: 3,
+        slug: 'otp-service',
+        title: 'OTP Service',
+        description:
+          'Designed and developed OTP service used by ALAMI app users for security purposes.',
+        urlImage: '',
+        stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
+        urlLive:
+          'https://play.google.com/store/apps/details?id=com.alami_funder&pcampaignid=web_share'
+      },
+      {
+        id: 4,
+        slug: 'p2p-education-module',
+        title: 'P2P Education Module',
+        description:
+          'Designed and developed P2P Education module used by ALAMI app users to help educate users about ALAMI P2P.',
+        urlImage: '',
+        stacks: ['Java', 'Spring Boot', 'PostgreSQL'],
+        urlLive:
+          'https://play.google.com/store/apps/details?id=com.alami_funder&pcampaignid=web_share'
+      },
+      {
+        id: 5,
+        slug: 'sfmonitor-agent-connector-amq',
+        title: 'SFMonitor Agent, Connector & AMQ',
+        description:
+          'SFMonitor consists of three integrated modules: SFMonitor Agent, which listens to server activity, records request histories, monitors system and JVM resources, provides thread and stack-trace controls, and sends request/response events to RabbitMQ; SFMonitor AMQ, which consumes these messages from RabbitMQ and stores them as historical data in the database; and SFMonitor Bridge, which acts as a connector between the SFMonitor Dashboard and multiple SFMonitor Agents inside Docker containers, routing dashboard requests to the correct agent based on container IP or host.',
+        urlImage: '',
+        stacks: ['Java', 'Spring Boot', 'RabbitMQ', 'MySQL']
+      }
+    ]
   },
-  {
-    id: 'web',
+  web: {
     label: 'Website',
-    count: portfolioItems.filter((item) => item.category === 'web').length
+    items: [
+      {
+        id: 1,
+        slug: 'wonderful-quran-web',
+        title: 'Wonderful Quran Web',
+        description:
+          'Designed and developed Wonderful Quran web with fast navigation, verse exploration, and a clean study interface',
+        urlImage: '',
+        stacks: ['TypeScript', 'React.js', 'Next.js', 'Tailwind CSS', 'Radix UI'],
+        urlLive: 'https://wonderful-quran.netlify.app/',
+        urlGitHub: 'https://github.com/ladoijo/wonderful-quran-fe'
+      },
+      {
+        id: 2,
+        slug: 'my-personal-web',
+        title: 'My Personal Web',
+        description:
+          'A personal portfolio website showcasing my projects, skills, and professional experience. Built with modern web technologies.',
+        urlImage: '',
+        stacks: ['TypeScript', 'React.js', 'Next.js', 'Tailwind CSS'],
+        urlLive: 'https://hdygidev.netlify.app/',
+        urlGitHub: 'https://github.com/ladoijo/my-personal-web'
+      },
+      {
+        id: 3,
+        slug: 'sfmonitor-dashboard',
+        title: 'SFMonitor Dashboard',
+        description:
+          'Designed and developed monitoring dashboard equipped with features to monitor requests, responses, resource usage, and more from every server, VM, and Docker container service related to Lucee and ColdFusion applications.',
+        urlImage: '',
+        stacks: ['Spring MVC', 'CSS', 'JavaScript', 'jQuery', 'Bootstrap']
+      }
+    ]
   },
-  {
-    id: 'mobile',
-    label: 'Mobile Apps',
-    count: portfolioItems.filter((item) => item.category === 'mobile').length
-  },
-  {
-    id: 'desktop',
-    label: 'Desktop Apps',
-    count: portfolioItems.filter((item) => item.category === 'desktop').length
+  mobile: {
+    label: 'Mobile',
+    items: [
+      {
+        id: 1,
+        slug: 'navees',
+        title: 'Navees',
+        description:
+          'Developed app specializing in the buying and selling of gold bars, facilitates online gold trading using the wakalah contract, ensuring transactions align with Sharia principles for a secure and ethical experience.',
+        urlImage: '',
+        stacks: ['TypeScript', 'React Native', 'Redux', 'RxJS', 'NativeBase'],
+        urlLive: 'https://play.google.com/store/apps/details?id=com.navees&pcampaignid=web_share'
+      }
+    ]
   }
-];
+};
 
 export interface ISkill {
   [key: string]: {

--- a/src/sections/about/index.tsx
+++ b/src/sections/about/index.tsx
@@ -1,5 +1,6 @@
 import CompanyIcon from '@/assets/icons/company.svg';
 import ExperienceIcon from '@/assets/icons/experience.svg';
+import Chip from '@/components/Chip';
 import Paper from '@/components/Paper';
 import { WorkExperiences } from '@/constants/HistoriesConst';
 import { NavItems } from '@/constants/NavItemsConst';
@@ -61,24 +62,13 @@ const About = () => {
               sm:grid-cols-[6rem_1fr_6rem_1fr] sm:grid-rows-2
             `}
           >
-            <p className={`h-fit w-fit rounded-sm bg-blue-600 px-1.5 font-semibold text-white`}>
-              Name
-            </p>
+            <Chip text="Name" size="md" textColor="white" />
             <p className={`border-b-1 border-dotted`}>Hadyan Putra Yasrizal</p>
-
-            <p className={`h-fit w-fit rounded-sm bg-blue-600 px-1.5 font-semibold text-white`}>
-              Freelance
-            </p>
+            <Chip text="Freelance" size="md" textColor="white" />
             <p className={`border-b-1 border-dotted text-green-600`}>Available</p>
-
-            <p className={`h-fit w-fit rounded-sm bg-blue-600 px-1.5 font-semibold text-white`}>
-              Nationality
-            </p>
+            <Chip text="Nationality" size="md" textColor="white" />
             <p className={`border-b-1 border-dotted`}>Indonesia</p>
-
-            <p className={`h-fit w-fit rounded-sm bg-blue-600 px-1.5 font-semibold text-white`}>
-              Location
-            </p>
+            <Chip text="Location" size="md" textColor="white" />
             <p className={`border-b-1 border-dotted`}>Bandung Regency, Indonesia</p>
           </div>
         </div>

--- a/src/sections/about/index.tsx
+++ b/src/sections/about/index.tsx
@@ -95,7 +95,7 @@ const About = () => {
             <div
               className={`
                 absolute z-1 flex h-48 w-full items-center justify-center rounded-md border-2
-                border-black bg-[#E3F2FF] p-4 transition-transform duration-300 ease-in-out
+                border-black bg-[var(--color-2)] p-4 transition-transform duration-300 ease-in-out
                 group-hover:scale-105
               `}
             >
@@ -126,7 +126,7 @@ const About = () => {
             <div
               className={`
                 absolute z-1 flex h-48 w-full items-center justify-center rounded-md border-2
-                border-black bg-[#F3FFe3] p-4 transition-transform duration-300 ease-in-out
+                border-black bg-[var(--color-3)] p-4 transition-transform duration-300 ease-in-out
                 group-hover:scale-105
               `}
             >

--- a/src/sections/contact/ContactLink.tsx
+++ b/src/sections/contact/ContactLink.tsx
@@ -4,7 +4,7 @@ import styles from './contact.module.css';
 
 interface ContactLinkProps {
   href: string;
-  icon: React.ComponentType<{ name: string; className?: string }>;
+  icon: React.ComponentType<{ name: string; className?: string; style?: React.CSSProperties }>;
   iconName: string;
   title: string;
   description?: string;
@@ -19,46 +19,32 @@ const ContactLink = memo(
     iconName,
     title,
     description,
-    iconBgColor,
-    iconTextColor = 'text-white'
-  }: ContactLinkProps) => {
-    const getHoverBgColor = (bgClass: string): string => {
-      const colorMap: Record<string, string> = {
-        'bg-[#f87171]': '#f87171',
-        'bg-[#2dd4bf]': '#2dd4bf',
-        'bg-[#3b82f6]': '#3b82f6',
-        'bg-[#00bba7]': '#00bba7',
-        'bg-[#26ab15]': '#26ab15',
-        'bg-[#4b5563]': '#4b5563'
-      };
-      return colorMap[bgClass] || '#000000';
-    };
-
-    return (
-      <Link
-        href={href}
-        className={styles.contactLink}
-        style={
-          {
-            '--hover-bg-color': getHoverBgColor(iconBgColor)
-          } as React.CSSProperties
-        }
-      >
-        <Icon
-          name={iconName}
-          className={`
-            h-16 w-16 p-2 transition-colors duration-300
-            ${iconBgColor}
-            ${iconTextColor}
-          `}
-        />
-        <div className={`flex flex-col p-2`}>
-          <h3 className="font-bold">{title}</h3>
-          {description && <span className="text-gray-500">{description}</span>}
-        </div>
-      </Link>
-    );
-  }
+    iconBgColor = '#000000',
+    iconTextColor = 'var(--color-6)'
+  }: ContactLinkProps) => (
+    <Link
+      href={href}
+      className={styles.contactLink}
+      style={
+        {
+          '--hover-bg-color': iconBgColor
+        } as React.CSSProperties
+      }
+    >
+      <Icon
+        name={iconName}
+        style={{
+          backgroundColor: iconBgColor,
+          color: iconTextColor
+        }}
+        className="h-16 w-16 p-2 transition-colors duration-300"
+      />
+      <div className="flex flex-col p-2">
+        <h3 className="font-bold">{title}</h3>
+        {description && <span className="text-gray-500">{description}</span>}
+      </div>
+    </Link>
+  )
 );
 
 ContactLink.displayName = 'ContactLink';

--- a/src/sections/contact/index.tsx
+++ b/src/sections/contact/index.tsx
@@ -170,7 +170,7 @@ const Contact = memo(() => {
               )}
             </div>
             <Button
-              bgColor="#7fcec6"
+              bgColor="var(--color-7)"
               className={`
                 h-12 w-full
                 sm:w-auto
@@ -231,7 +231,7 @@ const Contact = memo(() => {
                   iconName={AccountUrls.mail.name}
                   title="Email"
                   description={AccountUrls.mail.placeholder}
-                  iconBgColor="bg-[#f87171]"
+                  iconBgColor="#f87171"
                 />
                 <ContactLink
                   href={AccountUrls.phone.url}
@@ -239,7 +239,7 @@ const Contact = memo(() => {
                   iconName={AccountUrls.phone.name}
                   title="Phone"
                   description={AccountUrls.phone.placeholder}
-                  iconBgColor="bg-[#2dd4bf]"
+                  iconBgColor="#2dd4bf"
                 />
               </div>
             </section>
@@ -259,7 +259,7 @@ const Contact = memo(() => {
                   iconName={AccountUrls.linkedin.name}
                   title="LinkedIn"
                   description={AccountUrls.linkedin.placeholder}
-                  iconBgColor="bg-[#3b82f6]"
+                  iconBgColor="#3b82f6"
                 />
                 <ContactLink
                   href={AccountUrls.whatsapp.url}
@@ -267,7 +267,7 @@ const Contact = memo(() => {
                   iconName={AccountUrls.whatsapp.name}
                   title="WhatsApp"
                   description={AccountUrls.whatsapp.placeholder}
-                  iconBgColor="bg-[#00bba7]"
+                  iconBgColor="#00bba7"
                 />
               </div>
             </section>
@@ -287,7 +287,7 @@ const Contact = memo(() => {
                   iconName={AccountUrls.upwork.name}
                   title="Upwork"
                   description={AccountUrls.upwork.placeholder}
-                  iconBgColor="bg-[#26ab15]"
+                  iconBgColor="#26ab15"
                 />
                 <ContactLink
                   href={AccountUrls.contra.url}
@@ -295,8 +295,8 @@ const Contact = memo(() => {
                   iconName={AccountUrls.contra.name}
                   title="Contra"
                   description={AccountUrls.contra.placeholder}
-                  iconBgColor="bg-[#4b5563]"
-                  iconTextColor="text-[#fcc462]"
+                  iconBgColor="#4b5563"
+                  iconTextColor="#fcc462"
                 />
               </div>
             </section>

--- a/src/sections/home/index.tsx
+++ b/src/sections/home/index.tsx
@@ -91,7 +91,7 @@ const Home = () => {
             <Button bgColor="#7fcec6" className="h-10 w-30" onClick={handleGetInTouchClick}>
               Get in Touch
             </Button>
-            <Button bgColor="#f9c9c9" className="h-10 w-36" onClick={handleSeeMyWorksClick}>
+            <Button bgColor="var(--color-4)" className="h-10 w-36" onClick={handleSeeMyWorksClick}>
               See My Works
             </Button>
           </div>

--- a/src/sections/portfolio/PortfolioItem.tsx
+++ b/src/sections/portfolio/PortfolioItem.tsx
@@ -1,102 +1,107 @@
+import Button from '@/components/Button';
 import Chip from '@/components/Chip';
-import { ProjectItem as PortfolioItemType } from '@/types/portfolio';
-import Image from 'next/image';
-import React from 'react';
+import ImageSafe from '@/components/ImageSafe';
+import { IPortfolioProject } from '@/constants/ResumeConst';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 interface PortfolioItemProps {
-  item: PortfolioItemType;
-  onClick?: (item: PortfolioItemType) => void;
+  bgColor?: string;
+  item: IPortfolioProject['items'][0];
 }
 
-const PortfolioItem: React.FC<PortfolioItemProps> = ({ item, onClick }) => {
-  const handleClick = () => {
-    onClick?.(item);
+const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor, item }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [descriptionHeight, setDescriptionHeight] = useState(0);
+  const descriptionRef = useRef<HTMLDivElement>(null);
+  const hasExternalLink = Boolean(item.urlLive || item.urlGitHub);
+  const collapsedHeight = 60;
+  const containerBg = useMemo(() => {
+    const colors = ['#fdebc3', '#E3F2FF', '#F3FFe3', '#f9c9c9', '#a2cef1', '#ffffff', '#7fcec6'];
+    const index =
+      item.title.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) % colors.length;
+    return colors[index];
+  }, [item.title]);
+
+  const handleOpenLink = (url?: string) => {
+    if (!url) return;
+    window.open(url, '_blank');
   };
+
+  useEffect(() => {
+    const paragraphEl = descriptionRef.current;
+    if (!paragraphEl) return;
+
+    const updateHeight = () => setDescriptionHeight(paragraphEl.scrollHeight);
+    updateHeight();
+
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(paragraphEl);
+    return () => resizeObserver.disconnect();
+  }, [item.description]);
 
   return (
     <div
       className={`
-        group cursor-pointer overflow-hidden rounded-xl border-2 border-black bg-white p-3
+        group mb-8 cursor-pointer break-inside-avoid-column overflow-hidden rounded-xl border-2 border-black p-3 ${bgColor}
         transition-all duration-300
         hover:-translate-y-1
       `}
-      onTouchStart={handleClick}
+      onClick={() => setIsExpanded(!isExpanded)}
     >
-      <div className="h-full w-full rounded-xl border-2 border-black p-3">
-        <div className="relative h-48 w-full overflow-hidden">
-          <Image
-            src={item.image}
+      <div className="flex h-full w-full flex-col rounded-lg border-2 border-black bg-white">
+        <div className="relative flex min-h-48 w-full overflow-hidden">
+          <ImageSafe
+            src={item.urlImage}
             alt={item.title}
             className={`
-              h-full w-full object-cover transition-transform duration-300
+              bg-black object-contain transition-transform duration-300
               group-hover:scale-105
             `}
             fill
-            priority={item.featured}
           />
-          <div
-            className={`
-              absolute inset-0 flex items-center justify-center bg-black opacity-0
-              transition-opacity duration-300
-              group-hover:opacity-100
-            `}
-          >
+        </div>
+
+        <div className="flex h-full flex-col justify-between gap-2 p-6">
+          <div className="flex flex-col gap-2">
+            <h3 className="text-xl font-semibold text-gray-800">{item.title}</h3>
             <div
-              className={`
-                flex flex-col gap-2
-                md:flex-row md:gap-4
-              `}
+              className="relative flex flex-col items-start overflow-hidden transition-[max-height] duration-500 ease-in-out"
+              ref={descriptionRef}
+              style={{
+                maxHeight: isExpanded
+                  ? Math.max(descriptionHeight, collapsedHeight)
+                  : collapsedHeight
+              }}
             >
-              {item.liveUrl && (
-                <a
-                  href={item.liveUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`
-                    rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors
-                    duration-300
-                    hover:bg-blue-700
-                  `}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  Live Demo
-                </a>
-              )}
-              {item.githubUrl && (
-                <a
-                  href={item.githubUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`
-                    rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors
-                    duration-300
-                    hover:bg-blue-700
-                  `}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  GitHub
-                </a>
+              <p className="leading-relaxed text-gray-600">{item.description}</p>
+              <div className="mt-2 flex w-full flex-row flex-wrap gap-3 p-1.5">
+                {hasExternalLink && item.urlLive && (
+                  <Button
+                    className="flex-1"
+                    bgColor="#7fcec6"
+                    onClick={() => handleOpenLink(item.urlLive)}
+                  >
+                    Live Demo
+                  </Button>
+                )}
+                {hasExternalLink && item.urlGitHub && (
+                  <Button
+                    className="flex-1"
+                    bgColor="#f9c9c9"
+                    onClick={() => handleOpenLink(item.urlGitHub)}
+                  >
+                    GitHub
+                  </Button>
+                )}
+              </div>
+              {!isExpanded && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-white" />
               )}
             </div>
           </div>
-          {item.featured && (
-            <div
-              className={`
-                absolute top-4 right-4 rounded-full bg-red-500 px-3 py-1 text-xs font-semibold
-                tracking-wider text-white uppercase
-              `}
-            >
-              Featured
-            </div>
-          )}
-        </div>
-
-        <div className="p-6">
-          <h3 className="mb-2 text-xl font-semibold text-gray-800">{item.title}</h3>
-          <p className="mb-4 leading-relaxed text-gray-600">{item.description}</p>
-          <div className="flex flex-wrap gap-2">
-            {item.technologies.map((tech) => (
-              <Chip key={tech} text={tech} bgColor="#37353E" />
+          <div className="mt-2 flex flex-row flex-wrap gap-2">
+            {item.stacks.map((stack) => (
+              <Chip key={stack} text={stack} textColor="#FFFFFF" />
             ))}
           </div>
         </div>

--- a/src/sections/portfolio/PortfolioItem.tsx
+++ b/src/sections/portfolio/PortfolioItem.tsx
@@ -2,25 +2,19 @@ import Button from '@/components/Button';
 import Chip from '@/components/Chip';
 import ImageSafe from '@/components/ImageSafe';
 import { IPortfolioProject } from '@/constants/ResumeConst';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface PortfolioItemProps {
   bgColor?: string;
   item: IPortfolioProject['items'][0];
 }
 
-const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor, item }) => {
+const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor = 'var(--color-1)', item }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [descriptionHeight, setDescriptionHeight] = useState(0);
   const descriptionRef = useRef<HTMLDivElement>(null);
   const hasExternalLink = Boolean(item.urlLive || item.urlGitHub);
   const collapsedHeight = 60;
-  const containerBg = useMemo(() => {
-    const colors = ['#fdebc3', '#E3F2FF', '#F3FFe3', '#f9c9c9', '#a2cef1', '#ffffff', '#7fcec6'];
-    const index =
-      item.title.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) % colors.length;
-    return colors[index];
-  }, [item.title]);
 
   const handleOpenLink = (url?: string) => {
     if (!url) return;
@@ -42,26 +36,26 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor, item }) => {
   return (
     <div
       className={`
-        group mb-8 cursor-pointer break-inside-avoid-column overflow-hidden rounded-xl border-2 border-black p-3 ${bgColor}
-        transition-all duration-300
-        hover:-translate-y-1
+        group mb-8 cursor-pointer break-inside-avoid-column overflow-hidden rounded-xl border-2 border-black p-3
+        transition-all duration-300 hover:-translate-y-1
       `}
+      style={{ backgroundColor: bgColor }}
       onClick={() => setIsExpanded(!isExpanded)}
     >
-      <div className="flex h-full w-full flex-col rounded-lg border-2 border-black bg-white">
+      <div className="flex h-full w-full flex-col overflow-hidden rounded-lg border-2 border-black bg-black">
         <div className="relative flex min-h-48 w-full overflow-hidden">
           <ImageSafe
             src={item.urlImage}
             alt={item.title}
-            className={`
-              bg-black object-contain transition-transform duration-300
-              group-hover:scale-105
+            className={`object-contain transition-transform duration-300
+              group-hover:scale-120
             `}
-            fill
+            width={1024}
+            height={768}
           />
         </div>
 
-        <div className="flex h-full flex-col justify-between gap-2 p-6">
+        <div className="flex h-full flex-col justify-between gap-2 border-t-2 bg-white p-6">
           <div className="flex flex-col gap-2">
             <h3 className="text-xl font-semibold text-gray-800">{item.title}</h3>
             <div
@@ -87,7 +81,7 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor, item }) => {
                 {hasExternalLink && item.urlGitHub && (
                   <Button
                     className="flex-1"
-                    bgColor="#f9c9c9"
+                    bgColor="var(--color-4)"
                     onClick={() => handleOpenLink(item.urlGitHub)}
                   >
                     GitHub
@@ -101,7 +95,7 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor, item }) => {
           </div>
           <div className="mt-2 flex flex-row flex-wrap gap-2">
             {item.stacks.map((stack) => (
-              <Chip key={stack} text={stack} textColor="#FFFFFF" />
+              <Chip key={stack} text={stack} textColor="var(--color-6)" />
             ))}
           </div>
         </div>

--- a/src/sections/portfolio/PortfolioItem.tsx
+++ b/src/sections/portfolio/PortfolioItem.tsx
@@ -36,18 +36,24 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor = 'var(--color-1)
   return (
     <div
       className={`
-        group mb-8 cursor-pointer break-inside-avoid-column overflow-hidden rounded-xl border-2 border-black p-3
-        transition-all duration-300 hover:-translate-y-1
+        group mb-8 cursor-pointer break-inside-avoid-column overflow-hidden rounded-xl border-2
+        border-black p-3 transition-all duration-300
+        hover:-translate-y-1
       `}
       style={{ backgroundColor: bgColor }}
       onClick={() => setIsExpanded(!isExpanded)}
     >
-      <div className="flex h-full w-full flex-col overflow-hidden rounded-lg border-2 border-black bg-black">
+      <div
+        className={`
+          flex h-full w-full flex-col overflow-hidden rounded-lg border-2 border-black bg-black
+        `}
+      >
         <div className="relative flex min-h-48 w-full overflow-hidden">
           <ImageSafe
             src={item.urlImage}
             alt={item.title}
-            className={`object-contain transition-transform duration-300
+            className={`
+              object-contain transition-transform duration-300
               group-hover:scale-120
             `}
             width={1024}
@@ -59,7 +65,10 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor = 'var(--color-1)
           <div className="flex flex-col gap-2">
             <h3 className="text-xl font-semibold text-gray-800">{item.title}</h3>
             <div
-              className="relative flex flex-col items-start overflow-hidden transition-[max-height] duration-500 ease-in-out"
+              className={`
+                relative flex flex-col items-start overflow-hidden transition-[max-height]
+                duration-500 ease-in-out
+              `}
               ref={descriptionRef}
               style={{
                 maxHeight: isExpanded
@@ -89,7 +98,11 @@ const PortfolioItem: React.FC<PortfolioItemProps> = ({ bgColor = 'var(--color-1)
                 )}
               </div>
               {!isExpanded && (
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-white" />
+                <div
+                  className={`
+                    pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-white
+                  `}
+                />
               )}
             </div>
           </div>

--- a/src/sections/portfolio/index.tsx
+++ b/src/sections/portfolio/index.tsx
@@ -27,7 +27,7 @@ const Portfolio = () => {
   }, [hasProjects]);
 
   const filteredItems = useMemo(() => {
-    let items: IPortfolioProject['items'] = [];
+    const items: IPortfolioProject['items'] = [];
     if (selectedCategory === 'all') {
       for (const value of Object.values(PortfolioProjects)) {
         items.push(...value.items);
@@ -41,7 +41,12 @@ const Portfolio = () => {
   return (
     <Paper id={NavItems[4].id} title="Portfolio" bgColor="#e3e3ff">
       <div className="flex w-full flex-col gap-8">
-        <div className="flex flex-wrap justify-center gap-4 md:justify-start">
+        <div
+          className={`
+            flex flex-wrap justify-center gap-4
+            md:justify-start
+          `}
+        >
           <Button pressed={selectedCategory === 'all'} onClick={() => setSelectedCategory('all')}>
             All ({totalProject})
           </Button>

--- a/src/sections/portfolio/index.tsx
+++ b/src/sections/portfolio/index.tsx
@@ -7,6 +7,12 @@ import { IPortfolioProject, PortfolioProjects } from '@/constants/ResumeConst';
 import { useMemo, useRef, useState } from 'react';
 import PortfolioItem from './PortfolioItem';
 
+const categoryColors: Record<string, string> = {
+  backend: 'var(--color-5)',
+  web: 'var(--color-3)',
+  mobile: 'var(--color-4)'
+};
+
 const Portfolio = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const portfolioRef = useRef<HTMLDivElement>(null);
@@ -60,9 +66,20 @@ const Portfolio = () => {
                 lg:columns-3
               `}
             >
-              {filteredItems.map((item) => (
-                <PortfolioItem key={item.slug} item={item} />
-              ))}
+              {filteredItems.map((item) => {
+                const category =
+                  Object.entries(PortfolioProjects).find(([_, project]) =>
+                    project.items.some((i) => i.slug === item.slug)
+                  )?.[0] || 'all';
+
+                return (
+                  <PortfolioItem
+                    key={item.slug}
+                    item={item}
+                    bgColor={categoryColors[category] || categoryColors['all']}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="py-12 text-center text-gray-600">

--- a/src/sections/portfolio/index.tsx
+++ b/src/sections/portfolio/index.tsx
@@ -3,66 +3,74 @@
 import Button from '@/components/Button';
 import Paper from '@/components/Paper';
 import { NavItems } from '@/constants/NavItemsConst';
-import { portfolioItems, projectCategories } from '@/constants/ResumeConst';
-import { ProjectItem as PortfolioItemType } from '@/types/portfolio';
-import { useMemo, useState } from 'react';
+import { IPortfolioProject, PortfolioProjects } from '@/constants/ResumeConst';
+import { useMemo, useRef, useState } from 'react';
 import PortfolioItem from './PortfolioItem';
 
 const Portfolio = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const portfolioRef = useRef<HTMLDivElement>(null);
+  const hasProjects = Object.keys(PortfolioProjects).length;
+  const totalProject = useMemo(() => {
+    if (!hasProjects) return 0;
+    let count = 0;
+    for (const value of Object.values(PortfolioProjects)) {
+      count += value.items.length;
+    }
+    return count;
+  }, [hasProjects]);
 
   const filteredItems = useMemo(() => {
+    let items: IPortfolioProject['items'] = [];
     if (selectedCategory === 'all') {
-      return portfolioItems;
+      for (const value of Object.values(PortfolioProjects)) {
+        items.push(...value.items);
+      }
+    } else {
+      items.push(...PortfolioProjects[selectedCategory].items);
     }
-    return portfolioItems.filter((item) => item.category === selectedCategory);
+    return items;
   }, [selectedCategory]);
-
-  const handleItemClick = (item: PortfolioItemType) => {
-    console.log('Portfolio item clicked:', item);
-  };
 
   return (
     <Paper id={NavItems[4].id} title="Portfolio" bgColor="#e3e3ff">
-      <div className="w-full">
-        {/* Category Filter */}
-        <div
-          className={`
-            mb-8 flex flex-wrap justify-center gap-4
-            md:justify-start
-          `}
-        >
-          {projectCategories.map((category) => (
+      <div className="flex w-full flex-col gap-8">
+        <div className="flex flex-wrap justify-center gap-4 md:justify-start">
+          <Button pressed={selectedCategory === 'all'} onClick={() => setSelectedCategory('all')}>
+            All ({totalProject})
+          </Button>
+          {Object.entries(PortfolioProjects).map(([key, value]) => (
             <Button
-              key={category.id}
-              bgColor="#DDEB9D"
-              pressed={selectedCategory === category.id}
-              onClick={() => setSelectedCategory(category.id)}
+              key={key}
+              pressed={selectedCategory === key}
+              onClick={() => {
+                setSelectedCategory(key);
+              }}
             >
-              {category.label} ({category.count})
+              {value.label} ({value.items.length})
             </Button>
           ))}
         </div>
-
-        {/* Portfolio Grid */}
-        {filteredItems.length > 0 ? (
-          <div
-            className={`
-              mt-8 grid grid-cols-1 gap-8
-              md:grid-cols-2
-              lg:grid-cols-3
-            `}
-          >
-            {filteredItems.map((item) => (
-              <PortfolioItem key={item.id} item={item} onClick={handleItemClick} />
-            ))}
-          </div>
-        ) : (
-          <div className="py-12 text-center text-gray-600">
-            <h3 className="mb-4 text-gray-800">No projects found</h3>
-            <p>No projects match the selected category.</p>
-          </div>
-        )}
+        <div ref={portfolioRef} className="relative flex flex-col items-start overflow-hidden pt-1">
+          {filteredItems.length > 0 ? (
+            <div
+              className={`
+                columns-1 gap-x-8
+                md:columns-2
+                lg:columns-3
+              `}
+            >
+              {filteredItems.map((item) => (
+                <PortfolioItem key={item.slug} item={item} />
+              ))}
+            </div>
+          ) : (
+            <div className="py-12 text-center text-gray-600">
+              <h3 className="mb-4 text-gray-800">No projects found</h3>
+              <p>No projects match the selected category.</p>
+            </div>
+          )}
+        </div>
       </div>
     </Paper>
   );

--- a/src/sections/resume/SectionEducation.tsx
+++ b/src/sections/resume/SectionEducation.tsx
@@ -39,7 +39,14 @@ const SectionEducation = () => {
                   lg:grid-cols-[140px_auto_1fr]
                 `}
               >
-                <b className="hidden text-right lg:block">{ed.degree}</b>
+                <b
+                  className={`
+                    hidden text-right
+                    lg:block
+                  `}
+                >
+                  {ed.degree}
+                </b>
                 <VerticalLineConnector type="education" />
                 <div
                   className={`

--- a/src/sections/resume/SectionEducation.tsx
+++ b/src/sections/resume/SectionEducation.tsx
@@ -36,17 +36,10 @@ const SectionEducation = () => {
                 key={ed.id}
                 className={`
                   grid grid-cols-[auto_1fr] items-start gap-2
-                  lg:grid-cols-[auto_auto_1fr]
+                  lg:grid-cols-[140px_auto_1fr]
                 `}
               >
-                <div
-                  className={`
-                    hidden
-                    lg:block
-                  `}
-                >
-                  <b>{ed.degree}</b>
-                </div>
+                <b className="hidden text-right lg:block">{ed.degree}</b>
                 <VerticalLineConnector type="education" />
                 <div
                   className={`

--- a/src/sections/resume/components/CardWorkSummary.tsx
+++ b/src/sections/resume/components/CardWorkSummary.tsx
@@ -40,7 +40,7 @@ const CardWorkSummary = ({
           <small>Stack:</small>
           <div className="flex flex-wrap items-center gap-1">
             {workExperience.stacks?.map((stack) => (
-              <Chip key={stack} text={stack} bgColor="#4300FF" textColor="#FFFFFF" />
+              <Chip size="xs" key={stack} text={stack} textColor="#FFFFFF" />
             ))}
           </div>
         </div>

--- a/src/sections/resume/components/CardWorkSummary.tsx
+++ b/src/sections/resume/components/CardWorkSummary.tsx
@@ -40,7 +40,7 @@ const CardWorkSummary = ({
           <small>Stack:</small>
           <div className="flex flex-wrap items-center gap-1">
             {workExperience.stacks?.map((stack) => (
-              <Chip size="xs" key={stack} text={stack} textColor="#FFFFFF" />
+              <Chip size="xs" key={stack} text={stack} textColor="var(--color-6)" />
             ))}
           </div>
         </div>

--- a/src/sections/resume/components/VerticalLineConnector.tsx
+++ b/src/sections/resume/components/VerticalLineConnector.tsx
@@ -4,7 +4,9 @@ import BriefcaseIcon from '@/assets/icons/portfolio.svg';
 const VerticalLineConnector = ({ type }: { type: 'work' | 'education' }) => (
   <div className="relative flex h-full flex-col items-center">
     <div
-      className={`z-11 flex h-7 w-7 items-center justify-center rounded-full border-2 bg-[var(--color-7)]`}
+      className={`
+        z-11 flex h-7 w-7 items-center justify-center rounded-full border-2 bg-[var(--color-7)]
+      `}
     >
       {type === 'work' ? (
         <BriefcaseIcon className="h-4 w-4 items-center justify-center text-black" />

--- a/src/sections/resume/components/VerticalLineConnector.tsx
+++ b/src/sections/resume/components/VerticalLineConnector.tsx
@@ -4,7 +4,7 @@ import BriefcaseIcon from '@/assets/icons/portfolio.svg';
 const VerticalLineConnector = ({ type }: { type: 'work' | 'education' }) => (
   <div className="relative flex h-full flex-col items-center">
     <div
-      className={`z-11 flex h-7 w-7 items-center justify-center rounded-full border-2 bg-[#7fcec6]`}
+      className={`z-11 flex h-7 w-7 items-center justify-center rounded-full border-2 bg-[var(--color-7)]`}
     >
       {type === 'work' ? (
         <BriefcaseIcon className="h-4 w-4 items-center justify-center text-black" />

--- a/src/sections/service/index.tsx
+++ b/src/sections/service/index.tsx
@@ -2,7 +2,7 @@ import Paper from '@/components/Paper';
 import { NavItems } from '@/constants/NavItemsConst';
 
 const Service = () => {
-  return <Paper id={NavItems[3].id} title="My Services" />;
+  return <Paper id={NavItems[3].id} title="My Services" className="bg-dots" />;
 };
 
 export default Service;

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -15,9 +15,9 @@ export interface EmailResponse {
 const ERR_CONFIG_MESSAGE = 'EmailJS configuration is incomplete';
 
 class EmailService {
-  private serviceId: string;
-  private templateId: string;
-  private publicKey: string;
+  private readonly serviceId: string;
+  private readonly templateId: string;
+  private readonly publicKey: string;
 
   constructor() {
     this.serviceId = process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID || '';


### PR DESCRIPTION
## Summary
-  replaces placeholder portfolio scaffolding with a typed PortfolioProjects map powered by real project entries plus updated skill colors, letting the rest of the site consume consistent palette tokens.
- rebuild the portfolio grid with category-aware filtering, masonry layout, expandable cards, and a resilient image component while enabling the Service and Portfolio sections on the homepage.
- apply shared color variables and UI tweaks across About, Resume, Contact, and navigation for a cohesive look and safer defaults.

## Testing
- [x] pnpm lint
- [x] pnpm build
- [x] pnpm dev